### PR TITLE
chore: make package public

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ Publishing is triggered by nrk.no team using CI infrastructure (nrkno-sanity-lib
 
 See [packages documentation](docs/packages.md).
 
+**Note:** Packages are _private_ on npm by default. 
+Add 
+```json
+  "publishConfig": {
+    "access": "public"
+  }
+```
+to package.json to make it public on npm.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -3,6 +3,16 @@
 
 This repo uses [Hygen templates](http://www.hygen.io/docs/templates) to simplify package creation. 
 
+**Note:** Packages are _private_ on npm by default.
+Add
+```json
+  "publishConfig": {
+    "access": "public"
+  }
+```
+to package.json to make it public on npm.
+
+
 ### Sanity plugin
 > npm run package:sanity-plugin
 

--- a/packages/nrkno-sanity-typesafe-schemas/package.json
+++ b/packages/nrkno-sanity-typesafe-schemas/package.json
@@ -4,6 +4,9 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nrkno/nrkno-sanity-libs.git",

--- a/packages/sanity-plugin-nrkno-odd-utils/package.json
+++ b/packages/sanity-plugin-nrkno-odd-utils/package.json
@@ -4,6 +4,9 @@
   "main": "./build/index.js",
   "types": "./plugin-types/index.d.ts",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nrkno/nrkno-sanity-libs.git",


### PR DESCRIPTION
## Scope
Gjør typesafe-schemas og odd-utils public!

Når jeg har oppdatert nrkno-sanity med dette, gjør jeg repo public også!

## Reviewers

Vit om at dette skjer.
Les endrede docs.

## Checklist
I have:
- [X] used [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] committed with git-hooks active (ran npm install at least once locally before committing)
- [x] considered if this is a breaking change
- [ ] tested the changes using npm link / yarn link
- [x] triggered nrkno-sanity-libs-releaser for this branch and checked the status

The branch-build must be manually triggered by the nrk.no team using nrkno-sanity-libs-releaser.

After merging, new version(s) should be published to npm by by triggering
nrkno-sanity-libs-releaser for the master branch.

These manual steps are a safeguard to prevent accidental releases and version changes.

