### PR TITLE
feat: debug config available

### DIFF
--- a/packages/nrkno-iframe-preview-api/README.md
+++ b/packages/nrkno-iframe-preview-api/README.md
@@ -19,6 +19,8 @@ _Figure 1: Sanity form editor in the left pane, IFramePreview showing iframe con
 
 Refer to [jsdocs for each config-param](src/types.ts) for details.
 
+For any issues, see "Usage checklist" and "Debugging issues" below.
+
 ## Basic usage
 
 ```ts
@@ -54,6 +56,20 @@ const unloadPreview = initPreview<QueryResult | undefined>(
 unloadPreview()
 ```
 
+## Usage Checklist
+
+Ensure that:
+* your query explicitly contains _rev as a projected field. For details, see "About the _rev field".
+* queryParams function is invoked, and that you are returning an object with all query parameters used by your query.
+  * Example query: `* [slug=$slug]{_rev, _id, slug, title, body }[0]`
+  * Example queryParams: `doc => {slug: doc.slug}`
+  * Note: the doc passed to queryParams is active document in Sanity Studio, not the one returned by the groqQuery
+* the setData function handles `undefined` values.
+* the setData function is receiving data, is updating your view and not is throwing an error.
+
+Use `debug: true` for diagnostics (see below). Use it to find the query and params used for each update by the Studio to debug parameterized queries (for instance, by running
+them in Vision).
+
 ## Advanced usage
 
 ```ts
@@ -82,6 +98,22 @@ const unloadPreview = initPreview<QueryResult | undefined>(
 
 // whenever the component that uses the preview is unmounted, ensure to call
 unloadPreview()
+```
+
+### Debugging issues
+Provide `debug: true` as a config parameter.
+The log messages in console.log should provide a trace of any issues.
+
+```ts
+initPreview<QueryResult | undefined>(
+    {
+      // This flag will make the lib log messages being passed between Sanity Studio and the iframe 
+      debug: true,
+      // debug: process.env.NODE_ENV !== production
+      groqQuery: "* [_type='my-page' && _id == $id]{_rev, ...}[0]",
+    },
+    (data) => {/* omitted */ }
+)
 ```
 
 ## Use Studio document as is
@@ -179,5 +211,8 @@ npm link
 cd /path/to/your/render/app
 npm link  @nrk/sanity-plugin-nrkno-iframe-preview
 ```
+
+If you use volta, you must ensure that your render app also uses volta, otherwise
+npm link will not work correctly.
 
 Remember to use localhost url in the Studio to test the IFramePreview component with the app using the linked lib.

--- a/packages/nrkno-iframe-preview-api/src/iframe-preview.ts
+++ b/packages/nrkno-iframe-preview-api/src/iframe-preview.ts
@@ -78,7 +78,7 @@ export function initPreview<T>(
       .then((query) => {
         if (!query || !query.includes('_rev')) {
           throw new Error(
-            `Invalid groq-message. Query MUST contain _rev as a projected field ala {_rev, ...}. Please refer to the docs.\n
+            `Invalid groq-message. Query MUST contain _rev as a projected field ala {_rev, ...}. Please refer to the docs at https://github.com/nrkno/nrkno-sanity-libs/tree/master/packages/nrkno-iframe-preview-api#about-the-_rev-field\n
             Query was:\n${query}`
           );
         }

--- a/packages/nrkno-iframe-preview-api/src/types.ts
+++ b/packages/nrkno-iframe-preview-api/src/types.ts
@@ -53,6 +53,21 @@ export interface PreviewConfig<T> {
    * {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#syntax passed to postMessage targetOrigin}
    */
   origin?: string;
+
+  /**
+   * When true, the iframe-api-code will log debug-messages in console.log.
+   *
+   * This is useful to determine why the preview is not working correctly (spinner not disappearing ect),
+   * or to get insight into the message-flow between the Studio and iframe.
+   *
+   * Since the iframe is embedded in Sanity Studio, these messages will appear in the
+   * browser console of the Studio. IFramePreview can be configured to emit debug-logs separately.
+   *
+   * debug can also be a function conforming to console.log signature.
+   * The function will be used in place of console.log.
+   *
+   */
+  debug?: boolean | typeof console.log;
 }
 
 export interface StudioDocument {


### PR DESCRIPTION

NRKNO-4478


## Scope

La til ny config-param som gjør at man får en chatty log som forhåpentligvis gjør det enklere å debugge.
Fjernet sjekk på at event har _id til fordel for _rev (som jo faktisk blir validert).

@ajaco har du mulighet til å legge inn dette libbet i nettvideo soonish?

@mollerse tror du denne checklisten i readme og/eller debug logging hadde hjulpet i Åpen gate :crossed_fingers: ?
![image](https://user-images.githubusercontent.com/835514/152157083-690ec640-07c3-4bdf-8a35-b0f5e112098e.png)

## Reviewers
Les gjennom oppdatet review, og jsdocs. 
Se eventuelt på koden.

## Checklist
I have:
- [x] used [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] committed with git-hooks active (ran npm install at least once locally before committing)
- [x] considered if this is a breaking change
- [x] tested the changes using npm link / yarn link
- [x] triggered nrkno-sanity-libs-releaser for this branch and checked the status


Branch: NRKNO-4478-debug-iframe-api
- @nrk/nrkno-iframe-preview-api: 1.1.2 => 1.2.0
