### PR TITLE
feat: add render to blockeditor

### DIFF
--- a/packages/nrkno-sanity-typesafe-schemas/src/schemas/object.ts
+++ b/packages/nrkno-sanity-typesafe-schemas/src/schemas/object.ts
@@ -28,6 +28,7 @@ export interface ObjectSchema extends SanitySchemaBase {
   /** [Customize block editor](https://www.sanity.io/docs/customization) */
   blockEditor?: {
     icon?: (props: unknown) => ReactNode;
+    render?: (props: unknown) => ReactNode;
   };
 
   fields: GenericField[];


### PR DESCRIPTION
## Scope
Sanity allows custom renderer for annotations. Update type to reflect this
https://www.sanity.io/docs/customization#4a5f6f12693a

## Reviewers
<!-- what do you expect reviewers to do? -->

## Checklist
I have:
- [x] used [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] committed with git-hooks active (ran npm install at least once locally before committing)
- [x] considered if this is a breaking change
- [x] tested the changes using npm link / yarn link
- [ ] triggered nrkno-sanity-libs-releaser for this branch and checked the status

The branch-build must be manually triggered by the nrk.no team using nrkno-sanity-libs-releaser.

After merging, new version(s) should be published to npm by by triggering
nrkno-sanity-libs-releaser for the master branch.

These manual steps are a safeguard to prevent accidental releases and version changes.

